### PR TITLE
refactor: extract duplicate file extension list

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,6 @@
+/// File extensions that should be scanned for security issues
+pub const SCANNABLE_EXTENSIONS: &[&str] = &[
+    "rs", "js", "ts", "jsx", "tsx", "py", "go", "java", "c", "cpp", "h",
+    "hpp", "cs", "php", "rb", "swift", "kt", "scala", "sh", "bash",
+    "env", "yml", "yaml", "json", "toml", "sql"
+];

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod custom_rules;
 mod git;
 mod ignore;
 mod deps;
+mod constants;
 
 use scanner::Scanner;
 

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -7,6 +7,7 @@ use crate::patterns::PATTERNS;
 use crate::report::{Issue, Report, Severity};
 use crate::custom_rules::{load_custom_rules, CompiledRule};
 use crate::ignore::IgnorePatterns;
+use crate::constants::SCANNABLE_EXTENSIONS;
 
 pub struct Scanner {
     root_path: String,
@@ -120,12 +121,7 @@ impl Scanner {
         // Only scan text files
         if let Some(ext) = path.extension() {
             let ext = ext.to_string_lossy().to_lowercase();
-            matches!(
-                ext.as_str(),
-                "rs" | "js" | "ts" | "jsx" | "tsx" | "py" | "go" | "java" | "c" | "cpp" | "h"
-                    | "hpp" | "cs" | "php" | "rb" | "swift" | "kt" | "scala" | "sh" | "bash"
-                    | "env" | "yml" | "yaml" | "json" | "toml" | "sql"
-            )
+            SCANNABLE_EXTENSIONS.contains(&ext.as_str())
         } else {
             false
         }

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -6,6 +6,7 @@ use std::sync::mpsc::channel;
 use std::time::Duration;
 
 use crate::scanner::Scanner;
+use crate::constants::SCANNABLE_EXTENSIONS;
 
 pub fn watch_directory(path: &str, verbose: bool) -> Result<()> {
     println!("{}", "🛡️  AI Code Guardian - Watch Mode".cyan().bold());
@@ -56,12 +57,7 @@ fn should_scan(event: &Event) -> bool {
     ) && event.paths.iter().any(|p| {
         if let Some(ext) = p.extension() {
             let ext = ext.to_string_lossy().to_lowercase();
-            matches!(
-                ext.as_str(),
-                "rs" | "js" | "ts" | "jsx" | "tsx" | "py" | "go" | "java" | "c" | "cpp" | "h"
-                    | "hpp" | "cs" | "php" | "rb" | "swift" | "kt" | "scala" | "sh" | "bash"
-                    | "env" | "yml" | "yaml" | "json" | "toml" | "sql"
-            )
+            SCANNABLE_EXTENSIONS.contains(&ext.as_str())
         } else {
             false
         }


### PR DESCRIPTION
Fixes #1

Extracted the file extension list to a shared constant SCANNABLE_EXTENSIONS to eliminate duplication between scanner.rs and watch.rs.

**Changes:**
- Created new constants.rs module with SCANNABLE_EXTENSIONS
- Updated scanner.rs and watch.rs to use the shared constant
- Eliminates maintenance hazard of keeping two lists in sync