### PR TITLE
fix: improve hardcoded secret pattern to reduce false positives

### DIFF
--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -43,7 +43,7 @@ lazy_static::lazy_static! {
             title: "Hardcoded Secret",
             description: "Secret or password found in source code.",
             severity: Severity::High,
-            regex: Regex::new(r#"(?i)(password|passwd|pwd|secret|token)\s*[=:]\s*["']([^"'\s]{8,})["']"#).unwrap(),
+            regex: Regex::new(r#"(?i)(password|passwd|pwd|secret|token)\s*[=:]\s*["'](?!true|false|null|none|nil|<[^>]+>|\$\{[^}]+\}|\{\{[^}]+\}\}|Bearer|Basic)([^"'\s]{8,})["']"#).unwrap(),
             fix_suggestion: "Use environment variables: process.env.SECRET_KEY",
         },
         


### PR DESCRIPTION
Fixes #2

Updated the hardcoded secret regex to exclude common safe values to reduce noise from legitimate configuration.

**Changes:**
- Excludes boolean values: true, false
- Excludes null values: null, none, nil
- Excludes placeholder patterns: <...>, ${...}, {{...}}
- Excludes common config values: Bearer, Basic