### PR TITLE
refactor: use reqwest::blocking instead of tokio runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,6 @@ lazy_static = "1.5"
 crossterm = "0.27"
 ratatui = "0.26"
 notify = "6.1"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", features = ["json", "blocking"] }
 tokio = { version = "1.0", features = ["full"] }
 toml = "0.8"

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -189,7 +189,7 @@ fn parse_pyproject_toml(file_path: &Path) -> Result<Vec<Dependency>> {
     Ok(deps)
 }
 
-pub async fn check_vulnerability(client: &reqwest::Client, dep: &Dependency) -> Result<Vec<Vulnerability>> {
+pub fn check_vulnerability(client: &reqwest::blocking::Client, dep: &Dependency) -> Result<Vec<Vulnerability>> {
     let query = OsvQuery {
         package: OsvPackage {
             name: dep.name.clone(),
@@ -201,14 +201,13 @@ pub async fn check_vulnerability(client: &reqwest::Client, dep: &Dependency) -> 
     let response = client
         .post("https://api.osv.dev/v1/query")
         .json(&query)
-        .send()
-        .await?;
+        .send()?;
 
     if !response.status().is_success() {
         return Ok(Vec::new());
     }
 
-    let osv_response: OsvResponse = response.json().await?;
+    let osv_response: OsvResponse = response.json()?;
     
     let vulnerabilities = osv_response
         .vulns

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,16 +131,14 @@ fn main() -> Result<()> {
             watch::watch_directory(&path, verbose)?;
         }
         Commands::CheckDeps { path, json } => {
-            tokio::runtime::Runtime::new()?.block_on(async {
-                check_dependencies(&path, json).await
-            })?;
+            check_dependencies(&path, json)?;
         }
     }
 
     Ok(())
 }
 
-async fn check_dependencies(file_path: &str, json_output: bool) -> Result<()> {
+fn check_dependencies(file_path: &str, json_output: bool) -> Result<()> {
     use std::path::Path;
     
     let path = Path::new(file_path);
@@ -170,10 +168,10 @@ async fn check_dependencies(file_path: &str, json_output: bool) -> Result<()> {
 
     let mut total_vulns = 0;
     let mut results = Vec::new();
-    let client = reqwest::Client::new();
+    let client = reqwest::blocking::Client::new();
 
     for dep in &dependencies {
-        let vulns = deps::check_vulnerability(&client, dep).await?;
+        let vulns = deps::check_vulnerability(&client, dep)?;
         
         if !vulns.is_empty() {
             total_vulns += vulns.len();


### PR DESCRIPTION
Fixes #5

Replaced async/await with reqwest::blocking to avoid pulling in the full tokio runtime for a single HTTP operation.

**Changes:**
- Added blocking feature to reqwest
- Converted check_vulnerability to sync function
- Removed tokio runtime wrapper in main
- Simplifies code and reduces unnecessary async complexity