### PR TITLE
fix: replace deprecated f.size() with f.area() in TUI

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -172,7 +172,7 @@ fn ui(f: &mut Frame, app: &mut App) {
             Constraint::Length(8),
             Constraint::Length(3),
         ])
-        .split(f.size());
+        .split(f.area());
 
     // Header
     let header = Paragraph::new("🛡️  AI Code Guardian - Interactive Mode")


### PR DESCRIPTION
Fixes #8

Updated TUI code to use f.area() instead of the deprecated f.size() method.

**Changes:**
- Replaced f.size() with f.area()
- Follows ratatui best practices
- Removes deprecation warning