### PR TITLE
fix: restore scanner build and pattern checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,7 @@ dependencies = [
  "clap",
  "colored",
  "crossterm",
+ "globset",
  "lazy_static",
  "notify",
  "ratatui",
@@ -110,6 +111,16 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -415,6 +426,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,7 +450,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -449,6 +468,19 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]

--- a/src/git.rs
+++ b/src/git.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 
 pub fn get_changed_files(path: &str) -> Result<Vec<String>> {
     let output = Command::new("git")
-        .args(&["diff", "--name-only", "--diff-filter=ACMR"])
+        .args(["diff", "--name-only", "--diff-filter=ACMR"])
         .current_dir(path)
         .output()
         .context("Failed to execute git diff")?;
@@ -22,7 +22,7 @@ pub fn get_changed_files(path: &str) -> Result<Vec<String>> {
 
 pub fn get_staged_files(path: &str) -> Result<Vec<String>> {
     let output = Command::new("git")
-        .args(&["diff", "--cached", "--name-only", "--diff-filter=ACMR"])
+        .args(["diff", "--cached", "--name-only", "--diff-filter=ACMR"])
         .current_dir(path)
         .output()
         .context("Failed to execute git diff --cached")?;
@@ -41,7 +41,7 @@ pub fn get_staged_files(path: &str) -> Result<Vec<String>> {
 
 pub fn is_git_repo(path: &str) -> bool {
     Command::new("git")
-        .args(&["rev-parse", "--git-dir"])
+        .args(["rev-parse", "--git-dir"])
         .current_dir(path)
         .output()
         .map(|output| output.status.success())

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -1,5 +1,5 @@
-use regex::Regex;
 use crate::report::Severity;
+use regex::Regex;
 
 pub struct Pattern {
     pub title: &'static str,
@@ -43,7 +43,7 @@ lazy_static::lazy_static! {
             title: "Hardcoded Secret",
             description: "Secret or password found in source code.",
             severity: Severity::High,
-            regex: Regex::new(r#"(?i)(password|passwd|pwd|secret|token)\s*[=:]\s*["'](?!true|false|null|none|nil|<[^>]+>|\$\{[^}]+\}|\{\{[^}]+\}\}|Bearer|Basic)([^"'\s]{8,})["']"#).unwrap(),
+            regex: Regex::new(r#"(?i)(password|passwd|pwd|secret|token)\s*[=:]\s*["']([^"'\s]{8,})["']"#).unwrap(),
             fix_suggestion: "Use environment variables: process.env.SECRET_KEY",
         },
         

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -3,11 +3,11 @@ use std::fs;
 use std::path::Path;
 use walkdir::WalkDir;
 
-use crate::patterns::PATTERNS;
-use crate::report::{Issue, Report, Severity};
+use crate::constants::SCANNABLE_EXTENSIONS;
 use crate::custom_rules::{load_custom_rules, CompiledRule};
 use crate::ignore::IgnorePatterns;
-use crate::constants::SCANNABLE_EXTENSIONS;
+use crate::patterns::PATTERNS;
+use crate::report::{Issue, Report, Severity};
 
 pub struct Scanner {
     root_path: String,
@@ -157,6 +157,14 @@ impl Scanner {
                         continue;
                     }
 
+                    if pattern.title == "Hardcoded Secret" {
+                        if let Some(secret_value) = captures.get(2) {
+                            if self.is_safe_secret_value(secret_value.as_str()) {
+                                continue;
+                            }
+                        }
+                    }
+
                     issues.push(Issue {
                         severity: pattern.severity.clone(),
                         title: pattern.title.to_string(),
@@ -218,7 +226,7 @@ impl Scanner {
                 // Check if it's in 172.16.0.0 - 172.31.255.255 range
                 if let Some(second_octet) = ip.split('.').nth(1) {
                     if let Ok(num) = second_octet.parse::<u8>() {
-                        num >= 16 && num <= 31
+                        (16..=31).contains(&num)
                     } else {
                         false
                     }
@@ -226,5 +234,85 @@ impl Scanner {
                     false
                 }
             })
+    }
+
+    fn is_safe_secret_value(&self, value: &str) -> bool {
+        let lower_value = value.to_ascii_lowercase();
+
+        matches!(
+            lower_value.as_str(),
+            "true" | "false" | "null" | "none" | "nil" | "bearer" | "basic"
+        ) || (value.starts_with('<') && value.ends_with('>'))
+            || (value.starts_with("${") && value.ends_with('}'))
+            || (value.starts_with("{{") && value.ends_with("}}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn test_dir(name: &str) -> PathBuf {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = env::temp_dir().join(format!("ai-code-guardian-{name}-{suffix}"));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn scanner_initializes_builtin_patterns_without_panicking() {
+        let dir = test_dir("pattern-init");
+        fs::write(dir.join("main.rs"), "fn main() {}\n").unwrap();
+
+        let scanner = Scanner::new(dir.to_str().unwrap()).unwrap();
+        let report = scanner.scan(false).unwrap();
+
+        assert_eq!(report.files_scanned, 1);
+        assert!(report.issues.is_empty());
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn hardcoded_secret_ignores_placeholder_values() {
+        let dir = test_dir("placeholder-secret");
+        fs::write(
+            dir.join("config.rs"),
+            r#"
+const PASSWORD: &str = "<redacted>";
+const TOKEN: &str = "${API_TOKEN}";
+const SECRET: &str = "{{SECRET}}";
+"#,
+        )
+        .unwrap();
+
+        let scanner = Scanner::new(dir.to_str().unwrap()).unwrap();
+        let report = scanner.scan(false).unwrap();
+
+        assert!(report.issues.is_empty());
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn hardcoded_secret_reports_real_values() {
+        let dir = test_dir("real-secret");
+        fs::write(dir.join("config.rs"), r#"let token = "supersecretvalue";"#).unwrap();
+
+        let scanner = Scanner::new(dir.to_str().unwrap()).unwrap();
+        let report = scanner.scan(false).unwrap();
+
+        assert!(report
+            .issues
+            .iter()
+            .any(|issue| issue.title == "Hardcoded Secret"));
+
+        let _ = fs::remove_dir_all(dir);
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -172,7 +172,7 @@ fn ui(f: &mut Frame, app: &mut App) {
             Constraint::Length(8),
             Constraint::Length(3),
         ])
-        .split(f.area());
+        .split(f.size());
 
     // Header
     let header = Paragraph::new("🛡️  AI Code Guardian - Interactive Mode")


### PR DESCRIPTION
## Summary

Restores local Rust health checks by using the `ratatui` 0.26 `Frame::size()` API and syncing `Cargo.lock` with the declared `globset` dependency.

The scanner no longer panics when built-in patterns initialize: the unsupported regex look-ahead in the generic secret detector is replaced with Rust-side filtering for known placeholder values. This also clears the clippy warnings in the git helpers and private IP range check.

## Verification

- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo run -- scan examples`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-GPT--5-10a37f?logo=openai&logoColor=white)
