### PR TITLE
style: format Rust source

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,6 +1,5 @@
 /// File extensions that should be scanned for security issues
 pub const SCANNABLE_EXTENSIONS: &[&str] = &[
-    "rs", "js", "ts", "jsx", "tsx", "py", "go", "java", "c", "cpp", "h",
-    "hpp", "cs", "php", "rb", "swift", "kt", "scala", "sh", "bash",
-    "env", "yml", "yaml", "json", "toml", "sql"
+    "rs", "js", "ts", "jsx", "tsx", "py", "go", "java", "c", "cpp", "h", "hpp", "cs", "php", "rb",
+    "swift", "kt", "scala", "sh", "bash", "env", "yml", "yaml", "json", "toml", "sql",
 ];

--- a/src/custom_rules.rs
+++ b/src/custom_rules.rs
@@ -26,16 +26,15 @@ pub struct CompiledRule {
 
 pub fn load_custom_rules(path: &Path) -> Result<Vec<CompiledRule>> {
     let rules_file = path.join(".guardian.rules.json");
-    
+
     if !rules_file.exists() {
         return Ok(Vec::new());
     }
 
-    let content = fs::read_to_string(&rules_file)
-        .context("Failed to read custom rules file")?;
-    
-    let rules: Vec<CustomRule> = serde_json::from_str(&content)
-        .context("Failed to parse custom rules JSON")?;
+    let content = fs::read_to_string(&rules_file).context("Failed to read custom rules file")?;
+
+    let rules: Vec<CustomRule> =
+        serde_json::from_str(&content).context("Failed to parse custom rules JSON")?;
 
     let mut compiled = Vec::new();
     for rule in rules {
@@ -44,8 +43,10 @@ pub fn load_custom_rules(path: &Path) -> Result<Vec<CompiledRule>> {
             "medium" => Severity::Medium,
             "low" => Severity::Low,
             _ => {
-                eprintln!("Warning: Invalid severity '{}' in rule '{}', defaulting to Medium", 
-                    rule.severity, rule.title);
+                eprintln!(
+                    "Warning: Invalid severity '{}' in rule '{}', defaulting to Medium",
+                    rule.severity, rule.title
+                );
                 Severity::Medium
             }
         };
@@ -61,7 +62,10 @@ pub fn load_custom_rules(path: &Path) -> Result<Vec<CompiledRule>> {
                 });
             }
             Err(e) => {
-                eprintln!("Warning: Invalid regex pattern in rule '{}': {}", rule.title, e);
+                eprintln!(
+                    "Warning: Invalid regex pattern in rule '{}': {}",
+                    rule.title, e
+                );
             }
         }
     }

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -56,7 +56,8 @@ struct OsvReference {
 }
 
 pub fn parse_dependencies(file_path: &Path) -> Result<Vec<Dependency>> {
-    let filename = file_path.file_name()
+    let filename = file_path
+        .file_name()
         .and_then(|n| n.to_str())
         .context("Invalid filename")?;
 
@@ -102,8 +103,10 @@ fn parse_requirement_line(line: &str) -> Option<(&str, &str)> {
     for op in &["==", ">=", "<=", "~=", "!="] {
         if let Some(pos) = line.find(op) {
             let name = line[..pos].trim();
-            let version = line[pos + op.len()..].trim()
-                .split(',').next()? // Handle multiple constraints
+            let version = line[pos + op.len()..]
+                .trim()
+                .split(',')
+                .next()? // Handle multiple constraints
                 .trim();
             return Some((name, version));
         }
@@ -145,7 +148,9 @@ fn parse_package_json(file_path: &Path) -> Result<Vec<Dependency>> {
     }
 
     // Check optionalDependencies
-    if let Some(optional_dependencies) = json.get("optionalDependencies").and_then(|d| d.as_object()) {
+    if let Some(optional_dependencies) =
+        json.get("optionalDependencies").and_then(|d| d.as_object())
+    {
         for (name, version) in optional_dependencies {
             if let Some(ver) = version.as_str() {
                 let clean_ver = ver.trim_start_matches('^').trim_start_matches('~');
@@ -236,7 +241,10 @@ fn parse_pyproject_toml(file_path: &Path) -> Result<Vec<Dependency>> {
     Ok(deps)
 }
 
-pub fn check_vulnerability(client: &reqwest::blocking::Client, dep: &Dependency) -> Result<Vec<Vulnerability>> {
+pub fn check_vulnerability(
+    client: &reqwest::blocking::Client,
+    dep: &Dependency,
+) -> Result<Vec<Vulnerability>> {
     let query = OsvQuery {
         package: OsvPackage {
             name: dep.name.clone(),
@@ -255,18 +263,20 @@ pub fn check_vulnerability(client: &reqwest::blocking::Client, dep: &Dependency)
     }
 
     let osv_response: OsvResponse = response.json()?;
-    
+
     let vulnerabilities = osv_response
         .vulns
         .into_iter()
         .map(|v| {
-            let severity = v.database_specific
+            let severity = v
+                .database_specific
                 .as_ref()
                 .and_then(|db| db.get("severity"))
                 .and_then(|s| s.as_str())
                 .map(|s| s.to_string());
 
-            let references = v.references
+            let references = v
+                .references
                 .unwrap_or_default()
                 .into_iter()
                 .map(|r| Reference { url: r.url })
@@ -274,7 +284,9 @@ pub fn check_vulnerability(client: &reqwest::blocking::Client, dep: &Dependency)
 
             Vulnerability {
                 id: v.id,
-                summary: v.summary.unwrap_or_else(|| "No description available".to_string()),
+                summary: v
+                    .summary
+                    .unwrap_or_else(|| "No description available".to_string()),
                 severity,
                 references,
             }

--- a/src/ignore.rs
+++ b/src/ignore.rs
@@ -10,7 +10,7 @@ pub struct IgnorePatterns {
 impl IgnorePatterns {
     pub fn load(root_path: &Path) -> Result<Self> {
         let ignore_file = root_path.join(".guardianignore");
-        
+
         if !ignore_file.exists() {
             return Ok(Self {
                 glob_set: GlobSet::empty(),
@@ -19,13 +19,13 @@ impl IgnorePatterns {
 
         let content = fs::read_to_string(&ignore_file)?;
         let mut builder = GlobSetBuilder::new();
-        
+
         for line in content.lines() {
             let line = line.trim();
             if line.is_empty() || line.starts_with('#') {
                 continue;
             }
-            
+
             // Add the glob pattern
             if let Ok(glob) = Glob::new(line) {
                 builder.add(glob);

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,16 +2,16 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 use colored::*;
 
-mod scanner;
-mod patterns;
-mod report;
-mod tui;
-mod watch;
+mod constants;
 mod custom_rules;
+mod deps;
 mod git;
 mod ignore;
-mod deps;
-mod constants;
+mod patterns;
+mod report;
+mod scanner;
+mod tui;
+mod watch;
 
 use scanner::Scanner;
 
@@ -57,7 +57,7 @@ enum Commands {
         #[arg(short, long)]
         staged: bool,
     },
-    
+
     /// Watch directory for changes and scan automatically
     Watch {
         /// Directory to watch (default: current directory)
@@ -84,13 +84,20 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Scan { path, json, verbose, interactive, git, staged } => {
+        Commands::Scan {
+            path,
+            json,
+            verbose,
+            interactive,
+            git,
+            staged,
+        } => {
             let scanner = if git || staged {
                 if !git::is_git_repo(&path) {
                     eprintln!("Error: Not a git repository");
                     std::process::exit(1);
                 }
-                
+
                 let files = if staged {
                     git::get_staged_files(&path)?
                 } else {
@@ -141,29 +148,35 @@ fn main() -> Result<()> {
 
 fn check_dependencies(file_path: &str, json_output: bool) -> Result<()> {
     use std::path::Path;
-    
+
     let path = Path::new(file_path);
-    
+
     if !path.exists() {
         anyhow::bail!("File not found: {}", file_path);
     }
 
     if !json_output {
-        println!("{}", "🛡️  AI Code Guardian - Dependency Check".cyan().bold());
+        println!(
+            "{}",
+            "🛡️  AI Code Guardian - Dependency Check".cyan().bold()
+        );
         println!();
         println!("Checking: {}", file_path.yellow());
         println!();
     }
 
     let dependencies = deps::parse_dependencies(path)?;
-    
+
     if dependencies.is_empty() {
         println!("No dependencies found");
         return Ok(());
     }
 
     if !json_output {
-        println!("Found {} dependencies, checking for vulnerabilities...", dependencies.len());
+        println!(
+            "Found {} dependencies, checking for vulnerabilities...",
+            dependencies.len()
+        );
         println!();
     }
 
@@ -178,10 +191,10 @@ fn check_dependencies(file_path: &str, json_output: bool) -> Result<()> {
         }
 
         let vulns = deps::check_vulnerability(&client, dep)?;
-        
+
         if !vulns.is_empty() {
             total_vulns += vulns.len();
-            
+
             if json_output {
                 results.push(serde_json::json!({
                     "package": &dep.name,
@@ -199,9 +212,14 @@ fn check_dependencies(file_path: &str, json_output: bool) -> Result<()> {
                     };
 
                     println!("❌ {}: {}", severity_colored, vuln.id.red().bold());
-                    println!("   Package: {}@{} ({})", dep.name.cyan(), dep.version, dep.ecosystem);
+                    println!(
+                        "   Package: {}@{} ({})",
+                        dep.name.cyan(),
+                        dep.version,
+                        dep.ecosystem
+                    );
                     println!("   Summary: {}", vuln.summary);
-                    
+
                     if !vuln.references.is_empty() {
                         println!("   References:");
                         for reference in &vuln.references {
@@ -215,17 +233,29 @@ fn check_dependencies(file_path: &str, json_output: bool) -> Result<()> {
     }
 
     if json_output {
-        println!("{}", serde_json::to_string_pretty(&serde_json::json!({
-            "total_dependencies": dependencies.len(),
-            "vulnerable_packages": results.len(),
-            "total_vulnerabilities": total_vulns,
-            "results": results,
-        }))?);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "total_dependencies": dependencies.len(),
+                "vulnerable_packages": results.len(),
+                "total_vulnerabilities": total_vulns,
+                "results": results,
+            }))?
+        );
     } else {
         if total_vulns == 0 {
             println!("{}", "✅ No known vulnerabilities found!".green().bold());
         } else {
-            println!("{}", format!("Found {} vulnerabilities in {} packages", total_vulns, results.len()).red().bold());
+            println!(
+                "{}",
+                format!(
+                    "Found {} vulnerabilities in {} packages",
+                    total_vulns,
+                    results.len()
+                )
+                .red()
+                .bold()
+            );
             std::process::exit(1);
         }
     }

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -19,7 +19,7 @@ lazy_static::lazy_static! {
             regex: Regex::new(r#"(?i)(api[_-]?key|apikey|api[_-]?secret)\s*[=:]\s*["']([a-zA-Z0-9_\-]{20,})["']"#).unwrap(),
             fix_suggestion: "Use process.env.API_KEY or import from .env file",
         },
-        
+
         // AWS Keys
         Pattern {
             title: "AWS Access Key",
@@ -28,7 +28,7 @@ lazy_static::lazy_static! {
             regex: Regex::new(r"AKIA[0-9A-Z]{16}").unwrap(),
             fix_suggestion: "Store in AWS credentials file or use IAM roles",
         },
-        
+
         // Private Keys
         Pattern {
             title: "Private Key",
@@ -37,7 +37,7 @@ lazy_static::lazy_static! {
             regex: Regex::new(r"-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----").unwrap(),
             fix_suggestion: "Store private keys in secure key management system (AWS KMS, HashiCorp Vault)",
         },
-        
+
         // Generic Secrets
         Pattern {
             title: "Hardcoded Secret",
@@ -46,7 +46,7 @@ lazy_static::lazy_static! {
             regex: Regex::new(r#"(?i)(password|passwd|pwd|secret|token)\s*[=:]\s*["']([^"'\s]{8,})["']"#).unwrap(),
             fix_suggestion: "Use environment variables: process.env.SECRET_KEY",
         },
-        
+
         // SQL Injection
         Pattern {
             title: "SQL Injection Risk",
@@ -55,7 +55,7 @@ lazy_static::lazy_static! {
             regex: Regex::new(r#"(?i)(?:SELECT|INSERT|UPDATE|DELETE)\s+(?:FROM|INTO|SET).*\+.*["']"#).unwrap(),
             fix_suggestion: "Use parameterized queries: db.query('SELECT * FROM users WHERE id = ?', [userId])",
         },
-        
+
         // SQL Injection - Python f-strings
         Pattern {
             title: "SQL Injection Risk (f-string)",
@@ -64,7 +64,7 @@ lazy_static::lazy_static! {
             regex: Regex::new(r#"(?i)f["'].*(?:SELECT|INSERT|UPDATE|DELETE).*\{[^}]+\}.*["']"#).unwrap(),
             fix_suggestion: "Use parameterized queries: cursor.execute('SELECT * FROM users WHERE id = ?', (user_id,))",
         },
-        
+
         // SQL Injection - Template literals
         Pattern {
             title: "SQL Injection Risk (template literal)",
@@ -73,7 +73,7 @@ lazy_static::lazy_static! {
             regex: Regex::new(r"(?i)`.*(?:SELECT|INSERT|UPDATE|DELETE).*\$\{[^}]+\}.*`").unwrap(),
             fix_suggestion: "Use parameterized queries: db.query('SELECT * FROM users WHERE id = $1', [userId])",
         },
-        
+
         // SQL Injection - WHERE clause concatenation
         Pattern {
             title: "SQL Injection Risk (WHERE clause)",
@@ -82,7 +82,7 @@ lazy_static::lazy_static! {
             regex: Regex::new(r#"(?i)WHERE\s+\w+\s*=\s*['"]?\s*\+\s*\w+"#).unwrap(),
             fix_suggestion: "Use parameterized queries instead of string concatenation",
         },
-        
+
         // Insecure HTTP
         Pattern {
             title: "Insecure HTTP Connection",
@@ -91,7 +91,7 @@ lazy_static::lazy_static! {
             regex: Regex::new(r#"http://[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,}"#).unwrap(),
             fix_suggestion: "Change to HTTPS: https://...",
         },
-        
+
         // Eval usage - only in JS/Python contexts
         Pattern {
             title: "Dangerous eval() Usage",
@@ -100,7 +100,7 @@ lazy_static::lazy_static! {
             regex: Regex::new(r"(?:^|[^a-zA-Z0-9_])eval\s*\(").unwrap(),
             fix_suggestion: "Use JSON.parse() for data or refactor to avoid eval()",
         },
-        
+
         // Hardcoded IPs - exclude common safe IPs
         Pattern {
             title: "Hardcoded IP Address",
@@ -109,7 +109,7 @@ lazy_static::lazy_static! {
             regex: Regex::new(r"\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b").unwrap(),
             fix_suggestion: "Move to config file or environment variable",
         },
-        
+
         // JWT Secrets
         Pattern {
             title: "Hardcoded JWT Secret",
@@ -118,7 +118,7 @@ lazy_static::lazy_static! {
             regex: Regex::new(r#"(?i)jwt[_-]?secret\s*[=:]\s*["']([^"'\s]{8,})["']"#).unwrap(),
             fix_suggestion: "Use process.env.JWT_SECRET with a strong random value",
         },
-        
+
         // Database URLs
         Pattern {
             title: "Database Connection String",

--- a/src/report.rs
+++ b/src/report.rs
@@ -114,23 +114,18 @@ impl Report {
             issue.risk_score,
             issue.title.bold()
         );
-        println!(
-            "   {}: {}:{}",
-            "File".dimmed(),
-            issue.file,
-            issue.line
-        );
+        println!("   {}: {}:{}", "File".dimmed(), issue.file, issue.line);
         println!("   {}: {}", "Code".dimmed(), issue.code.dimmed());
         if !issue.matched.is_empty() && issue.matched != issue.code {
             println!("   {}: {}", "Match".dimmed(), issue.matched.yellow());
         }
         println!("   {}: {}", "Risk".dimmed(), issue.description);
-        
+
         // Print fix suggestion if available
         if let Some(fix) = &issue.fix_suggestion {
             println!("   {}: {}", "Fix".green().bold(), fix.green());
         }
-        
+
         println!();
     }
 }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -26,8 +26,8 @@ impl Scanner {
         let custom_rules = load_custom_rules(Path::new(&root_path))?;
         let ignore_patterns = IgnorePatterns::load(Path::new(&root_path))?;
 
-        Ok(Self { 
-            root_path, 
+        Ok(Self {
+            root_path,
             custom_rules,
             specific_files: None,
             ignore_patterns,
@@ -43,8 +43,8 @@ impl Scanner {
         let custom_rules = load_custom_rules(Path::new(&root_path))?;
         let ignore_patterns = IgnorePatterns::load(Path::new(&root_path))?;
 
-        Ok(Self { 
-            root_path, 
+        Ok(Self {
+            root_path,
             custom_rules,
             specific_files: Some(files),
             ignore_patterns,
@@ -103,12 +103,12 @@ impl Scanner {
     fn should_scan(&self, path: &Path) -> bool {
         // Skip common directories
         let path_str = path.to_string_lossy();
-        
+
         // Check ignore patterns
         if self.ignore_patterns.should_ignore(&path_str) {
             return false;
         }
-        
+
         if path_str.contains("/node_modules/")
             || path_str.contains("/target/")
             || path_str.contains("/.git/")
@@ -148,7 +148,8 @@ impl Scanner {
                     let matched = captures.get(0).map(|m| m.as_str()).unwrap_or("");
 
                     // Filter out safe HTTP URLs
-                    if pattern.title == "Insecure HTTP Connection" && self.is_safe_http_url(matched) {
+                    if pattern.title == "Insecure HTTP Connection" && self.is_safe_http_url(matched)
+                    {
                         continue;
                     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -129,13 +129,16 @@ pub fn run_tui(report: Report) -> Result<()> {
     let real_issues = app.get_real_issues();
     println!("\n📊 Summary:");
     println!("Total issues: {}", app.issues.len());
-    println!("Marked as false positives: {}", app.marked_false_positives.len());
+    println!(
+        "Marked as false positives: {}",
+        app.marked_false_positives.len()
+    );
     println!("Real issues: {}", real_issues.len());
 
     // Check if there are high-risk real issues
-    let has_high_risk = real_issues.iter().any(|issue| {
-        matches!(issue.severity, Severity::High)
-    });
+    let has_high_risk = real_issues
+        .iter()
+        .any(|issue| matches!(issue.severity, Severity::High));
 
     if has_high_risk {
         std::process::exit(1);
@@ -144,10 +147,7 @@ pub fn run_tui(report: Report) -> Result<()> {
     Ok(())
 }
 
-fn run_app<B: ratatui::backend::Backend>(
-    terminal: &mut Terminal<B>,
-    app: &mut App,
-) -> Result<()> {
+fn run_app<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, app: &mut App) -> Result<()> {
     loop {
         terminal.draw(|f| ui(f, app))?;
 
@@ -176,7 +176,11 @@ fn ui(f: &mut Frame, app: &mut App) {
 
     // Header
     let header = Paragraph::new("🛡️  AI Code Guardian - Interactive Mode")
-        .style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))
+        .style(
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )
         .block(Block::default().borders(Borders::ALL));
     f.render_widget(header, chunks[0]);
 
@@ -198,10 +202,7 @@ fn ui(f: &mut Frame, app: &mut App) {
                 "  "
             };
 
-            let content = format!(
-                "{}{} - {}:{}",
-                prefix, issue.title, issue.file, issue.line
-            );
+            let content = format!("{}{} - {}:{}", prefix, issue.title, issue.file, issue.line);
 
             ListItem::new(content).style(Style::default().fg(severity_color))
         })
@@ -235,7 +236,12 @@ fn ui(f: &mut Frame, app: &mut App) {
                 ]),
                 Line::from(""),
                 Line::from(vec![
-                    Span::styled("Fix: ", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+                    Span::styled(
+                        "Fix: ",
+                        Style::default()
+                            .fg(Color::Green)
+                            .add_modifier(Modifier::BOLD),
+                    ),
                     Span::styled(
                         issue.fix_suggestion.as_deref().unwrap_or("N/A"),
                         Style::default().fg(Color::Green),

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -5,8 +5,8 @@ use std::path::Path;
 use std::sync::mpsc::channel;
 use std::time::Duration;
 
-use crate::scanner::Scanner;
 use crate::constants::SCANNABLE_EXTENSIONS;
+use crate::scanner::Scanner;
 
 pub fn watch_directory(path: &str, verbose: bool) -> Result<()> {
     println!("{}", "🛡️  AI Code Guardian - Watch Mode".cyan().bold());
@@ -35,9 +35,11 @@ pub fn watch_directory(path: &str, verbose: bool) -> Result<()> {
                     println!();
                     println!("{}", "📝 File changed, rescanning...".yellow());
                     println!();
-                    
+
                     // Scan only the changed files
-                    let changed_files: Vec<String> = event.paths.iter()
+                    let changed_files: Vec<String> = event
+                        .paths
+                        .iter()
                         .filter_map(|p| {
                             p.strip_prefix(path)
                                 .ok()
@@ -45,13 +47,13 @@ pub fn watch_directory(path: &str, verbose: bool) -> Result<()> {
                                 .map(|s| s.to_string())
                         })
                         .collect();
-                    
+
                     if !changed_files.is_empty() {
                         if let Err(e) = run_scan_files(path, &changed_files, verbose) {
                             eprintln!("{}: {}", "Error".red(), e);
                         }
                     }
-                    
+
                     println!();
                     println!("{}", "👀 Watching for changes...".green());
                     println!();
@@ -65,17 +67,15 @@ pub fn watch_directory(path: &str, verbose: bool) -> Result<()> {
 
 fn should_scan(event: &Event) -> bool {
     // Only scan on modify and create events
-    matches!(
-        event.kind,
-        EventKind::Modify(_) | EventKind::Create(_)
-    ) && event.paths.iter().any(|p| {
-        if let Some(ext) = p.extension() {
-            let ext = ext.to_string_lossy().to_lowercase();
-            SCANNABLE_EXTENSIONS.contains(&ext.as_str())
-        } else {
-            false
-        }
-    })
+    matches!(event.kind, EventKind::Modify(_) | EventKind::Create(_))
+        && event.paths.iter().any(|p| {
+            if let Some(ext) = p.extension() {
+                let ext = ext.to_string_lossy().to_lowercase();
+                SCANNABLE_EXTENSIONS.contains(&ext.as_str())
+            } else {
+                false
+            }
+        })
 }
 
 fn run_scan(path: &str, verbose: bool) -> Result<()> {


### PR DESCRIPTION
Formats the Rust source with `cargo fmt` so the repository has a stable baseline for `cargo fmt -- --check`.

Verification: `cargo fmt -- --check`, `cargo test`, and `cargo clippy -- -D warnings`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-GPT--5-10a37f?logo=openai&logoColor=white)
