### PR TITLE
ci: add Rust health checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        run: rustup toolchain install stable --profile minimal --component clippy rustfmt
+        run: rustup toolchain install stable --profile minimal --component clippy --component rustfmt
 
       - name: Use stable toolchain
         run: rustup default stable
 
       - name: Cache cargo artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  rust:
+    name: Rust
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal --component clippy rustfmt
+
+      - name: Use stable toolchain
+        run: rustup default stable
+
+      - name: Cache cargo artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/git
+            ~/.cargo/registry
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Check formatting
+        run: cargo fmt -- --check
+
+      - name: Run tests
+        run: cargo test
+
+      - name: Run clippy
+        run: cargo clippy -- -D warnings
+
+      - name: Run self-scan
+        run: cargo run -- scan . --verbose


### PR DESCRIPTION
## Summary

Adds a GitHub Actions CI workflow for the Rust project so PRs and `main` pushes run the checks that caught the current regressions: formatting, tests, clippy warnings, and a repository self-scan.

The workflow uses the stable Rust toolchain with `rustfmt` and `clippy`, caches cargo artifacts, and keeps repository permissions read-only.

## Verification

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'workflow yaml ok'"`
- `cargo fmt -- --check`
- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo run -- scan . --verbose`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-GPT--5-10a37f?logo=openai&logoColor=white)
